### PR TITLE
Moved certificate load/store to seperate interface to allow custom stores

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ subprojects {
         bnd(
             'Bundle-Name': project.name,
             'Bundle-Vendor': 'Fraunhofer ISE', 'Bundle-SymbolicName': project.group + '.' + project.name,
-            'Export-Package': 'org.openmuc.jeebus.ship.api, org.openmuc.jeebus.ship.shipconnection'
+            'Export-Package': 'org.openmuc.jeebus.ship.api, org.openmuc.jeebus.ship.api.cert, org.openmuc.jeebus.ship.shipconnection'
         )
     }
 

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/ShipNodeConfiguration.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/ShipNodeConfiguration.java
@@ -10,10 +10,14 @@
 
 package org.openmuc.jeebus.ship.api;
 
+import org.openmuc.jeebus.ship.api.cert.CertificateStorage;
+import org.openmuc.jeebus.ship.api.cert.KeyStoreCertificateStorage;
+import org.openmuc.jeebus.ship.api.cert.MemoryCertificateStorage;
 import org.openmuc.jeebus.ship.node.ShipNodeImpl;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,12 +43,66 @@ public class ShipNodeConfiguration {
 
     private String serviceInstance;
 
-    private String alias;
-    private String certPath;
-    private char[] keyStorePassphrase;
-    private char[] keyPairPassphrase;
+    private CertificateStorage certificateStorage;
+
     private String distinguishedName;
+
     private int certificateValidityInDays;
+
+    /**
+     * Wrapper class for parameters for initial ship node configuration. If a
+     * certificate should be loaded or stored, use the other constructor instead
+     *
+     * @param ipAddresses
+     *     ip addresses of network interfaces to bind this Ship node to, example:
+     *     ["192.168.1.2" /* ethernet * /, "::1" /* loopback * /]
+     * @param port
+     *     port for initial server
+     * @param wssPath
+     *     wss path for initial server, example: "/ship/"
+     * @param keepAlive
+     *     indicates if keepAlive packets are allowed
+     * @param serviceId
+     *     host name for JmDNS instance (service discovery), example:
+     *     "EXAMPLEBRAND-EEB01M3EU-001122334455"
+     * @param serviceDomain
+     *     which domain for service types to listen to, example: "local"
+     * @param serviceInstance
+     *     service instance label for initial server, example: "Dishwasher
+     *     ExampleCompany EEB01M3EU"
+     * @param certificateStorage
+     *     certificate storage used to load and store the key pair
+     * @param distinguishedName
+     *     X.509 Distinguished Name, eg "CN=Test, L=London, C=GB". For IoT devices,
+     *     usually the DeviceID
+     * @param certificateValidityInDays
+     *     how many days the certificate should be valid for
+     */
+    public ShipNodeConfiguration(
+        Set<String> ipAddresses,
+        int port,
+        String wssPath,
+        boolean keepAlive,
+        String serviceId,
+        String serviceDomain,
+        String serviceInstance,
+        CertificateStorage certificateStorage,
+        String distinguishedName,
+        int certificateValidityInDays
+    ) {
+        this(
+            ipAddresses,
+            port,
+            wssPath,
+            keepAlive,
+            serviceId,
+            serviceDomain,
+            serviceInstance,
+            distinguishedName,
+            certificateValidityInDays
+        );
+        this.certificateStorage = certificateStorage;
+    }
 
     /**
      * Wrapper class for parameters for initial ship node configuration. If a
@@ -93,6 +151,58 @@ public class ShipNodeConfiguration {
         String distinguishedName,
         int certificateValidityInDays
     ) {
+        this(
+            ipAddresses,
+            port,
+            wssPath,
+            keepAlive,
+            serviceId,
+            serviceDomain,
+            serviceInstance,
+            new MemoryCertificateStorage(),
+            distinguishedName,
+            certificateValidityInDays
+        );
+    }
+
+    /**
+     * Wrapper class for parameters for initial ship node configuration. If a
+     * certificate should be loaded or stored, use the other constructor instead
+     *
+     * @param ipAddresses
+     *     ip addresses of network interfaces to bind this Ship node to, example:
+     *     ["192.168.1.2" /* ethernet * /, "::1" /* loopback * /]
+     * @param port
+     *     port for initial server
+     * @param wssPath
+     *     wss path for initial server, example: "/ship/"
+     * @param keepAlive
+     *     indicates if keepAlive packets are allowed
+     * @param serviceId
+     *     host name for JmDNS instance (service discovery), example:
+     *     "EXAMPLEBRAND-EEB01M3EU-001122334455"
+     * @param serviceDomain
+     *     which domain for service types to listen to, example: "local"
+     * @param serviceInstance
+     *     service instance label for initial server, example: "Dishwasher
+     *     ExampleCompany EEB01M3EU"
+     * @param distinguishedName
+     *     X.509 Distinguished Name, eg "CN=Test, L=London, C=GB". For IoT devices,
+     *     usually the DeviceID
+     * @param certificateValidityInDays
+     *     how many days the certificate should be valid for
+     */
+    private ShipNodeConfiguration(
+        Set<String> ipAddresses,
+        int port,
+        String wssPath,
+        boolean keepAlive,
+        String serviceId,
+        String serviceDomain,
+        String serviceInstance,
+        String distinguishedName,
+        int certificateValidityInDays
+    ) {
         this.ipAddresses = ipAddresses.stream().map(str -> {
             try {
                 return InetAddress.getByName(str);
@@ -109,9 +219,7 @@ public class ShipNodeConfiguration {
         this.serviceId = serviceId;
         this.serviceDomain = serviceDomain;
         this.serviceInstance = serviceInstance;
-        this.alias = alias;
-        this.keyStorePassphrase = keyStorePassphrase;
-        this.keyPairPassphrase = keyPairPassphrase;
+        this.certificateStorage = new MemoryCertificateStorage();
         this.distinguishedName = distinguishedName;
         this.certificateValidityInDays = certificateValidityInDays;
     }
@@ -208,7 +316,12 @@ public class ShipNodeConfiguration {
             distinguishedName,
             certificateValidityInDays
         );
-        this.certPath = parsePath(certPath);
+        this.certificateStorage = new KeyStoreCertificateStorage(
+            certPath,
+            alias,
+            keyStorePassphrase,
+            keyPairPassphrase
+        );
     }
 
     /**
@@ -283,7 +396,12 @@ public class ShipNodeConfiguration {
             distinguishedName,
             certificateValidityInDays
         );
-        this.certPath = parsePath(certPath);
+        this.certificateStorage = new KeyStoreCertificateStorage(
+            certPath,
+            alias,
+            keyStorePassphrase,
+            keyPairPassphrase
+        );
     }
 
     /**
@@ -355,7 +473,12 @@ public class ShipNodeConfiguration {
             distinguishedName,
             certificateValidityInDays
         );
-        this.certPath = parsePath(certPath);
+        this.certificateStorage = new KeyStoreCertificateStorage(
+            certPath,
+            alias,
+            keyStorePassphrase,
+            keyPairPassphrase
+        );
     }
 
 
@@ -421,10 +544,6 @@ public class ShipNodeConfiguration {
             distinguishedName,
             certificateValidityInDays
         );
-    }
-
-    private String parsePath(String path) {
-        return path.replace("/", "\\");
     }
 
     public boolean isClientOnly() {
@@ -514,27 +633,27 @@ public class ShipNodeConfiguration {
     }
 
     public String getAlias() {
-        return alias;
-    }
-
-    public void setAlias(String alias) {
-        this.alias = alias;
+        return this.getKeyStoreCertStore()
+            .map(KeyStoreCertificateStorage::getAlias)
+            .orElse(null);
     }
 
     public String getCertPath() {
-        return certPath;
-    }
-
-    public void setCertPath(String certPath) {
-        this.certPath = certPath;
+        return this.getKeyStoreCertStore()
+            .map(KeyStoreCertificateStorage::getPathToKeyStore)
+            .orElse(null);
     }
 
     public char[] getKeyStorePassphrase() {
-        return keyStorePassphrase;
+        return this.getKeyStoreCertStore()
+            .map(KeyStoreCertificateStorage::getKeyStorePassphrase)
+            .orElse(null);
     }
 
     public char[] getKeyPairPassphrase() {
-        return keyPairPassphrase;
+        return this.getKeyStoreCertStore()
+            .map(KeyStoreCertificateStorage::getKeyPairPassphrase)
+            .orElse(null);
     }
 
     public String getDistinguishedName() {
@@ -543,6 +662,13 @@ public class ShipNodeConfiguration {
 
     public int getCertificateValidityInDays() {
         return certificateValidityInDays;
+    }
+
+    private Optional<KeyStoreCertificateStorage> getKeyStoreCertStore() {
+        if (!(this.certificateStorage instanceof KeyStoreCertificateStorage)) {
+            return Optional.empty();
+        }
+        return Optional.of((KeyStoreCertificateStorage) this.certificateStorage);
     }
 
     @Override
@@ -556,11 +682,7 @@ public class ShipNodeConfiguration {
             ", serviceId='" + serviceId + '\'' +
             ", serviceDomain='" + serviceDomain + '\'' +
             ", serviceInstance='" + serviceInstance + '\'' +
-            ", alias='" + alias + '\'' +
-            ", certPath='" + certPath + '\'' +
-            // Maybe not output any passwords...
-            // ", keyStorePassphrase=" + Arrays.toString(keyStorePassphrase) +
-            // ", keyPairPassphrase=" + Arrays.toString(keyPairPassphrase) +
+            ", certificateStorage='" + certificateStorage + '\'' +
             ", dn='" + distinguishedName + '\'' +
             ", days=" + certificateValidityInDays +
             '}';

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/ShipNodeConfiguration.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/ShipNodeConfiguration.java
@@ -664,6 +664,10 @@ public class ShipNodeConfiguration {
         return certificateValidityInDays;
     }
 
+    public CertificateStorage getCertificateStorage() {
+        return this.certificateStorage;
+    }
+
     private Optional<KeyStoreCertificateStorage> getKeyStoreCertStore() {
         if (!(this.certificateStorage instanceof KeyStoreCertificateStorage)) {
             return Optional.empty();

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateInfo.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateInfo.java
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2026 Fraunhofer ISE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.openmuc.jeebus.ship.api.cert;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+public class CertificateInfo {
+    public final PrivateKey privateKey;
+    public final X509Certificate certificate;
+
+    public CertificateInfo(PrivateKey privateKey, X509Certificate certificate) {
+        this.privateKey = privateKey;
+        this.certificate = certificate;
+    }
+}

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateStorage.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateStorage.java
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2026 Fraunhofer ISE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.openmuc.jeebus.ship.api.cert;
+
+import java.util.Optional;
+
+public interface CertificateStorage {
+    Optional<CertificateInfo> readCertificate() throws CertificateStoreException;
+
+    void saveCertificate(CertificateInfo certificate) throws CertificateStoreException;
+}

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateStoreException.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/CertificateStoreException.java
@@ -8,17 +8,14 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-package org.openmuc.jeebus.ship.node;
+package org.openmuc.jeebus.ship.api.cert;
 
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
+/**
+ * Thrown when a CertificateStorage failed to load or store a certificate.
+ */
+public class CertificateStoreException extends Exception {
 
-public class CertificateInfo {
-    public final PrivateKey privateKey;
-    public final X509Certificate certificate;
-
-    public CertificateInfo(PrivateKey privateKey, X509Certificate certificate) {
-        this.privateKey = privateKey;
-        this.certificate = certificate;
+    public CertificateStoreException(String message, Exception innerException) {
+        super(message, innerException);
     }
 }

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/KeyStoreCertificateStorage.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/KeyStoreCertificateStorage.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Certificate storage that stores the certificate in java keychain files.
+ * Certificate storage that stores the certificate in java keystore files.
  */
 public class KeyStoreCertificateStorage implements CertificateStorage {
     protected static final Logger log = LoggerFactory.getLogger(KeyStoreCertificateStorage.class);

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/KeyStoreCertificateStorage.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/KeyStoreCertificateStorage.java
@@ -1,0 +1,198 @@
+/********************************************************************************
+ * Copyright (c) 2026 Fraunhofer ISE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.openmuc.jeebus.ship.api.cert;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Certificate storage that stores the certificate in java keychain files.
+ */
+public class KeyStoreCertificateStorage implements CertificateStorage {
+    protected static final Logger log = LoggerFactory.getLogger(KeyStoreCertificateStorage.class);
+
+    private final String pathToKeyStore;
+    private final String alias;
+    private final char[] keyStorePassphrase;
+    private final char[] keyPairPassphrase;
+
+    /**
+     * Creates a certificate storage that reads and stores the certificates in a java
+     * keystore file.
+     *
+     * @param pathToKeyStore
+     *     path where the key store exists or should be created
+     * @param alias
+     *     the alias for either the existing key pair or for the key pair to be
+     *     created
+     * @param keyStorePassphrase
+     *     passphrase for the key store
+     * @param keyPairPassphrase
+     *     passphrase for the key pair to be generated
+     */
+    public KeyStoreCertificateStorage(
+        String pathToKeyStore,
+        String alias,
+        char[] keyStorePassphrase,
+        char[] keyPairPassphrase
+    ) {
+        Objects.requireNonNull(pathToKeyStore);
+        Objects.requireNonNull(alias);
+
+        this.pathToKeyStore = pathToKeyStore;
+        this.alias = alias;
+        this.keyStorePassphrase = keyStorePassphrase;
+        this.keyPairPassphrase = keyPairPassphrase;
+    }
+
+    public String getPathToKeyStore() {
+        return this.pathToKeyStore;
+    }
+
+    public String getAlias() {
+        return this.alias;
+    }
+
+    public char[] getKeyStorePassphrase() {
+        return this.keyStorePassphrase;
+    }
+
+    public char[] getKeyPairPassphrase() {
+        return this.keyPairPassphrase;
+    }
+
+    @Override
+    public Optional<CertificateInfo> readCertificate()
+        throws CertificateStoreException
+    {
+        if (!this.doesKeyStoreExist()) {
+            return Optional.empty();
+        }
+
+        try {
+            KeyStore keyStore = this.loadKeyStore();
+            if (!keyStore.containsAlias(this.alias)) {
+                log.info("No certificate was found for alias {}.", alias);
+                return Optional.empty();
+            }
+
+            Certificate certificate = keyStore.getCertificate(this.alias);
+            Key key = keyStore.getKey(this.alias, this.keyPairPassphrase);
+
+            if (!(key instanceof PrivateKey)) {
+                throw new IllegalArgumentException(
+                    "The key stored in the specified key store does not contain a"
+                        + " valid private key under the given alias " + this.alias
+                );
+            }
+
+            return Optional.of(new CertificateInfo(
+                (PrivateKey) key,
+                (X509Certificate) certificate
+            ));
+        } catch (Exception ex) {
+            throw new CertificateStoreException("Failed to load key from keystore " + this.pathToKeyStore, ex);
+        }
+    }
+
+    @Override
+    public void saveCertificate(CertificateInfo certificate)
+        throws CertificateStoreException
+    {
+        try {
+            var keyStore = this.loadOrCreateKeyStore();
+
+            X509Certificate[] certChain = new X509Certificate[] { certificate.certificate };
+            keyStore.setKeyEntry(alias, certificate.privateKey, this.keyPairPassphrase, certChain);
+
+            try (
+                FileOutputStream fos = new FileOutputStream(this.pathToKeyStore);
+                // try-with-resource unlocks it automatically
+                FileLock ignored = fos.getChannel().lock()
+            ) {
+                keyStore.store(fos, this.keyStorePassphrase);
+            }
+        } catch (Exception ex) {
+            throw new CertificateStoreException("Exception while storing key pair in key store.", ex);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "KeyStoreCertificateStorage{" +
+            "pathToKeyStore=" + this.pathToKeyStore +
+            ", alias=" + this.alias +
+            // Maybe not output any passwords...
+            // ", keyStorePassphrase=" + Arrays.toString(keyStorePassphrase) +
+            // ", keyPairPassphrase=" + Arrays.toString(keyPairPassphrase) +
+            '}';
+    }
+
+    private KeyStore loadOrCreateKeyStore() throws
+        KeyStoreException,
+        NoSuchProviderException,
+        CertificateException,
+        IOException,
+        NoSuchAlgorithmException
+    {
+        if (!this.doesKeyStoreExist()) {
+            log.info(
+                "No keystore has been found under path {}. Creating a new one.",
+                pathToKeyStore
+            );
+            return this.createNewKeyStore();
+        }
+
+        return this.loadKeyStore();
+    }
+
+    private boolean doesKeyStoreExist() {
+        return Files.exists(Path.of(this.pathToKeyStore));
+    }
+
+    private KeyStore loadKeyStore() throws
+        KeyStoreException, NoSuchProviderException, IOException,
+        CertificateException, NoSuchAlgorithmException
+    {
+        // For reference: https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#keystore-types
+        KeyStore result = KeyStore.getInstance("pkcs12", "BC");
+
+        try (
+            FileInputStream fis = new FileInputStream(pathToKeyStore);
+            FileLock ignored = fis.getChannel().lock(0, Long.MAX_VALUE, true)
+        ) {
+            result.load(fis, this.keyStorePassphrase);
+        }
+        return result;
+    }
+
+    private KeyStore createNewKeyStore() throws
+        KeyStoreException, NoSuchProviderException, CertificateException,
+        IOException, NoSuchAlgorithmException
+    {
+        KeyStore result = KeyStore.getInstance("pkcs12", "BC");
+        result.load(null, this.keyStorePassphrase);
+        return result;
+    }
+}

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/MemoryCertificateStorage.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/api/cert/MemoryCertificateStorage.java
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2026 Fraunhofer ISE
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.openmuc.jeebus.ship.api.cert;
+
+import java.util.Optional;
+
+/**
+ * Certificate storage that stores the certificate only in memory.
+ */
+public class MemoryCertificateStorage implements CertificateStorage {
+    private CertificateInfo certificate;
+
+    @Override
+    public Optional<CertificateInfo> readCertificate() {
+        return Optional.ofNullable(this.certificate);
+    }
+
+    @Override
+    public void saveCertificate(CertificateInfo certificate) {
+        this.certificate = certificate;
+    }
+
+    @Override
+    public String toString() {
+        return "MemoryCertificateStorage{}";
+    }
+}

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
@@ -27,21 +27,15 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.encoders.Hex;
+import org.openmuc.jeebus.ship.api.cert.*;
 import org.openmuc.jeebus.ship.message.MessageUtility;
 import org.openmuc.jeebus.ship.node.websocket.SkiManagementInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.crypto.spec.SecretKeySpec;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.channels.FileLock;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.*;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
@@ -50,6 +44,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -60,11 +55,7 @@ public class KeyManagement {
     protected static final Logger log = LoggerFactory.getLogger(KeyManagement.class);
     private static final Map<String, SkiManagementInfo> trustedSkis
         = new ConcurrentHashMap<>();
-    private final KeyPair keyPair;
-    private final String pathToKeyStore;
     private final CertificateInfo cert;
-    private final char[] keyStorePass;
-    private final char[] keyPairPass;
     private final SubjectKeyIdentifier ownSki;
 
     /**
@@ -88,20 +79,8 @@ public class KeyManagement {
      *     usually the DeviceID
      * @param days
      *     how many days the certificate should be valid for
-     * @throws KeyStoreException
-     *     if a KeyStoreSpi implementation for the specified type is not available
-     *     from the specified provider
-     * @throws NoSuchProviderException
-     *     if the specified provider is not registered in the security provider list
-     * @throws IOException
-     *     if there is an I/O or format problem with the keystore data, if a password
-     *     is required but not given, or if the given password was incorrect
-     * @throws CertificateException
-     *     if any of the certificates in the keystore could not be loaded
-     * @throws NoSuchAlgorithmException
-     *     if the appropriate data integrity algorithm could not be found
-     * @throws UnrecoverableKeyException
-     *     if the key cannot be recovered (e.g., the given password is wrong).
+     * @throws CertificateStoreException
+     *     if the certificate storage implementation fails to load or store the key
      */
     public KeyManagement(
         String pathToKeyStore,
@@ -110,53 +89,72 @@ public class KeyManagement {
         char[] keyPairPassphrase,
         String distinguishedName,
         int days
-    ) throws
-        KeyStoreException,
-        NoSuchProviderException,
-        IOException,
-        CertificateException,
-        NoSuchAlgorithmException,
-        UnrecoverableKeyException
+    ) throws CertificateStoreException
     {
-        Objects.requireNonNull(alias);
-        this.pathToKeyStore = pathToKeyStore;
-        this.keyStorePass = keyStorePassphrase;
-        this.keyPairPass = keyPairPassphrase;
-        addBCProvider();
-        KeyStore keyStore = loadKeyStore();
-        if (keyStore.containsAlias(alias)) {
-            Certificate certificate = keyStore.getCertificate(alias);
-
-            Key key = keyStore.getKey(alias, keyPairPassphrase);
-            if (key instanceof PrivateKey) {
-                keyPair = new KeyPair(certificate.getPublicKey(), (PrivateKey) key);
-                ownSki = generateSki(certificate.getPublicKey());
-                cert = new CertificateInfo(
-                    (PrivateKey) key,
-                    (X509Certificate) certificate
-                );
-            }
-            else {
-                throw new IllegalArgumentException(
-                    "The key stored in the specified key store does not contain a"
-                        + " valid private key under the given alias"
-                );
-            }
-        }
-        else {
-            log.info(
-                "No certificate was found for alias {}. Creating a new one.",
-                alias
-            );
-            keyPair = createKeyPair();
-            ownSki = generateSki(keyPair.getPublic());
-            cert = createCertificate(keyPair, distinguishedName, days, null);
-            storeCertificate(alias);
-        }
+        this(createCertificateStorage(
+            pathToKeyStore,
+            alias,
+            keyStorePassphrase,
+            keyPairPassphrase
+        ), distinguishedName, days);
     }
 
-    private boolean keyStoreExists() {
-        return pathToKeyStore != null && Files.exists(Path.of(pathToKeyStore));
+    /**
+     * Loads the key by using the provided certificateStorage.
+     * If no key is found, a new key is created.
+     *
+     * @param certificateStorage Certificate storage used for loading and storing the
+     *     key
+     * @param distinguishedName
+     *     X.509 Distinguished Name, eg "CN=Test, L=London, C=GB". For IoT devices,
+     *     usually the DeviceID
+     * @param days
+     *     how many days the certificate should be valid for
+     * @throws CertificateStoreException
+     *     if the certificate storage implementation fails to load the key
+     */
+    public KeyManagement(
+        CertificateStorage certificateStorage,
+        String distinguishedName,
+        int days
+    ) throws CertificateStoreException
+    {
+        addBCProvider();
+
+        Optional<CertificateInfo> storedCert = certificateStorage.readCertificate();
+        if (storedCert.isPresent()) {
+            this.cert = storedCert.get();
+        } else {
+            this.cert = this.createCertificate(
+                createKeyPair(),
+                distinguishedName,
+                days,
+                null
+            );
+            certificateStorage.saveCertificate(this.cert);
+        }
+
+        this.ownSki = generateSki(this.cert.certificate.getPublicKey());
+    }
+
+    private static CertificateStorage createCertificateStorage(
+        String pathToKeyStore,
+        String alias,
+        char[] keyStorePassphrase,
+        char[] keyPairPassphrase
+    ) {
+        Objects.requireNonNull(alias);
+
+        if (pathToKeyStore == null) {
+            return new MemoryCertificateStorage();
+        } else {
+            return new KeyStoreCertificateStorage(
+                pathToKeyStore,
+                alias,
+                keyStorePassphrase,
+                keyPairPassphrase
+            );
+        }
     }
 
     public static SubjectKeyIdentifier generateSki(PublicKey publicKey) {
@@ -266,100 +264,6 @@ public class KeyManagement {
         trustedSkis.clear();
     }
 
-    private void storeCertificate(
-        String alias
-    ) throws
-        IOException,
-        CertificateException,
-        KeyStoreException,
-        NoSuchAlgorithmException,
-        NoSuchProviderException
-    {
-        KeyStore keyStore = loadKeyStore();
-        try {
-            X509Certificate[] certChain = new X509Certificate[] { cert.certificate };
-            keyStore.setKeyEntry(alias, keyPair.getPrivate(), keyPairPass, certChain);
-        }
-        catch (Exception e) {
-            log.error("Exception while storing key pair in key store.", e);
-        }
-
-        if (pathToKeyStore != null) {
-            try (
-                FileOutputStream fos = new FileOutputStream(pathToKeyStore);
-                // try-with-resource unlocks it automatically
-                FileLock ignored = fos.getChannel().lock()
-            ) {
-                keyStore.store(fos, keyStorePass);
-            }
-        }
-    }
-
-    private KeyStore loadKeyStore() throws
-        KeyStoreException,
-        NoSuchProviderException,
-        CertificateException,
-        IOException,
-        NoSuchAlgorithmException
-    {
-        // For reference: https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#keystore-types
-        KeyStore result = KeyStore.getInstance("pkcs12", "BC");
-        if (keyStoreExists()) {
-            try (
-                FileInputStream fis = new FileInputStream(pathToKeyStore);
-                FileLock ignored = fis.getChannel().lock(0, Long.MAX_VALUE, true)
-            ) {
-                result.load(fis, keyStorePass);
-            }
-        }
-        else {
-            if (pathToKeyStore != null) {
-                log.info(
-                    "No keystore has been found under path {}. Creating a new one.",
-                    pathToKeyStore
-                );
-            }
-            result.load(null, keyStorePass);
-        }
-        return result;
-    }
-
-    /**
-     * We are not sure what the symmetric key methods are for.
-     * Maybe this logic concerns SHIP 1.1.0.
-     * As they are used nowhere right now, they may change or be removed in the
-     * future.
-     * <p>
-     * TODO: figure this out.
-     */
-    @Deprecated
-    public void storeSymKeyInKeyStore(String alias) throws
-        NoSuchProviderException,
-        KeyStoreException,
-        CertificateException,
-        NoSuchAlgorithmException,
-        IOException
-    {
-        KeyStore specialKeyStore = KeyStore.getInstance("BKS", "BC");
-        if (keyStoreExists()) {
-            specialKeyStore.load(new FileInputStream(pathToKeyStore), keyStorePass);
-        }
-        else {
-            specialKeyStore.load(null, null);
-        }
-        // wrap the symmetric key
-        SecretKeySpec symmetricKey = createSymmetricKey();
-        KeyStore.SecretKeyEntry secret = new KeyStore.SecretKeyEntry(symmetricKey);
-        KeyStore.ProtectionParameter pwd = new KeyStore.PasswordProtection(
-            keyStorePass
-        );
-        specialKeyStore.setEntry(alias, secret, pwd);
-        // save the keystore file
-        try (FileOutputStream fos = new FileOutputStream(pathToKeyStore)) {
-            specialKeyStore.store(fos, keyStorePass);
-        }
-    }
-
     /**
      * Generates an asymmetric ECDHE key pair
      *
@@ -447,7 +351,7 @@ public class KeyManagement {
             certBuilder.addExtension(
                 Extension.subjectKeyIdentifier,
                 false,
-                this.ownSki
+                generateSki(keyPair.getPublic())
             );
 
             // Make the cert builder a cert authority in case more certs are needed

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
@@ -96,7 +96,7 @@ public class KeyManagement {
             alias,
             keyStorePassphrase,
             keyPairPassphrase
-        ), distinguishedName, days);
+        ), distinguishedName, distinguishedName, days);
     }
 
     /**

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
@@ -116,6 +116,7 @@ public class KeyManagement {
     public KeyManagement(
         CertificateStorage certificateStorage,
         String distinguishedName,
+        String serviceId,
         int days
     ) throws CertificateStoreException
     {
@@ -128,6 +129,7 @@ public class KeyManagement {
             this.cert = this.createCertificate(
                 createKeyPair(),
                 distinguishedName,
+                serviceId,
                 days,
                 null
             );
@@ -313,6 +315,7 @@ public class KeyManagement {
     public CertificateInfo createCertificate(
         KeyPair keyPair,
         String distinguishedName,
+        String serviceId,
         int days,
         CertificateInfo issuer
     ) {
@@ -364,7 +367,7 @@ public class KeyManagement {
             ASN1Encodable[] subjectAlternativeNames = new ASN1Encodable[] {
                 new GeneralName(
                     GeneralName.dNSName,
-                    "IP Address=" + distinguishedName
+                    serviceId
                 )
             };
             certBuilder.addExtension(

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/KeyManagement.java
@@ -33,7 +33,6 @@ import org.openmuc.jeebus.ship.node.websocket.SkiManagementInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.crypto.spec.SecretKeySpec;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.cert.CertificateException;
@@ -286,16 +285,6 @@ public class KeyManagement {
             throw new RuntimeException("Exception while generating EC KeyPair", e);
         }
         return gen.generateKeyPair();
-    }
-
-    /**
-     * @see KeyManagement#storeSymKeyInKeyStore
-     */
-    @Deprecated
-    private SecretKeySpec createSymmetricKey() {
-        byte[] keyBytes = new byte[16];
-        new SecureRandom().nextBytes(keyBytes);
-        return new SecretKeySpec(keyBytes, "AES");
     }
 
     /**

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
@@ -99,10 +99,7 @@ public class ShipNodeImpl {
 
         try {
             this.keyManagement = new KeyManagement(
-                nodeConfig.getCertPath(),
-                nodeConfig.getAlias(),
-                nodeConfig.getKeyStorePassphrase(),
-                nodeConfig.getKeyPairPassphrase(),
+                nodeConfig.getCertificateStorage(),
                 nodeConfig.getDistinguishedName(),
                 nodeConfig.getCertificateValidityInDays()
             );

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
@@ -31,11 +31,6 @@ import javax.jmdns.ServiceInfo;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.URI;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -101,6 +96,7 @@ public class ShipNodeImpl {
             this.keyManagement = new KeyManagement(
                 nodeConfig.getCertificateStorage(),
                 nodeConfig.getDistinguishedName(),
+                nodeConfig.getServiceId(),
                 nodeConfig.getCertificateValidityInDays()
             );
             log.info(

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/ShipNodeImpl.java
@@ -14,6 +14,7 @@ import io.netty.handler.ssl.SslContext;
 import org.openmuc.jeebus.ship.api.ClientConnectedCallBack;
 import org.openmuc.jeebus.ship.api.ConnectionHandler;
 import org.openmuc.jeebus.ship.api.ShipNodeConfiguration;
+import org.openmuc.jeebus.ship.api.cert.CertificateStoreException;
 import org.openmuc.jeebus.ship.message.connectionclose.ConnectionCloseReasonType;
 import org.openmuc.jeebus.ship.node.service.ServiceRegistry;
 import org.openmuc.jeebus.ship.node.service.TxtRecord;
@@ -110,14 +111,7 @@ public class ShipNodeImpl {
                 keyManagement.getOwnSkiAsStr()
             );
         }
-        catch (
-            KeyStoreException |
-            NoSuchProviderException |
-            CertificateException |
-            IOException |
-            NoSuchAlgorithmException |
-            UnrecoverableKeyException e
-        ) {
+        catch (CertificateStoreException e) {
             log.error("Exception while loading or creating key store: ", e);
             throw new RuntimeException(e);
             // if we don't exit here, there would be an NPE later anyway

--- a/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/SslContextFactory.java
+++ b/projects/ship/src/main/java/org/openmuc/jeebus/ship/node/SslContextFactory.java
@@ -14,6 +14,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.openmuc.jeebus.ship.api.cert.CertificateInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/projects/ship/src/test/java/org/openmuc/jeebus/ship/node/KeyManagementTest.java
+++ b/projects/ship/src/test/java/org/openmuc/jeebus/ship/node/KeyManagementTest.java
@@ -15,14 +15,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
+import org.openmuc.jeebus.ship.api.cert.CertificateInfo;
+import org.openmuc.jeebus.ship.api.cert.CertificateStoreException;
 
-import java.io.IOException;
+import java.io.File;
 import java.nio.file.Path;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -46,11 +43,10 @@ public class KeyManagementTest {
     private KeyManagement km;
 
     @BeforeEach
-    public void setUp() throws UnrecoverableKeyException, CertificateException,
-        KeyStoreException, IOException,
-        NoSuchAlgorithmException, NoSuchProviderException {
-        pathToKeyStore = tempDir.toString() + "/keystore.jks";
-        km = new KeyManagement(pathToKeyStore.replace("/", "\\"),
+    public void setUp() throws CertificateStoreException {
+        pathToKeyStore = tempDir.toString() + File.pathSeparator + "keystore.jks";
+        km = new KeyManagement(
+            pathToKeyStore,
             alias,
             keyStorePassphrase,
             keyPairPassphrase,

--- a/projects/ship/src/test/java/org/openmuc/jeebus/ship/node/KeyManagementTest.java
+++ b/projects/ship/src/test/java/org/openmuc/jeebus/ship/node/KeyManagementTest.java
@@ -16,10 +16,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.openmuc.jeebus.ship.api.cert.CertificateInfo;
+import org.openmuc.jeebus.ship.api.cert.CertificateStorage;
 import org.openmuc.jeebus.ship.api.cert.CertificateStoreException;
+import org.openmuc.jeebus.ship.api.cert.KeyStoreCertificateStorage;
+import org.openmuc.jeebus.ship.api.cert.MemoryCertificateStorage;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.security.cert.CertificateEncodingException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -28,29 +32,28 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @Execution(SAME_THREAD)
 public class KeyManagementTest {
 
-    private final String alias = "testKeys";
-    private final char[] keyStorePassphrase
+    private final String keystoreAlias = "testKeys";
+    private final char[] keystorePassphrase
         = "qyeditwsnj3k3l2sw7lt9sjlprahk1j0".toCharArray();
-    private final char[] keyPairPassphrase
+    private final char[] keystoreKeyPassphrase
         = "othj88udf6u7d2jjqmm37ysu5gx6vhei".toCharArray();
     private final String dn = "CN=Test, L=Freiburg, C=DE";
+    private final String shipId = "Test";
+
     private final int days = 1;
     private final String testSki = "1234AAAAFFFF1111CCCC3333EEEEDDDD99992222";
     private final String testSki2 = "1234AAAAFFFF1111CCCC3333EEEEDDDD99992223";
+
     @TempDir
     Path tempDir;
-    private String pathToKeyStore;
     private KeyManagement km;
 
     @BeforeEach
     public void setUp() throws CertificateStoreException {
-        pathToKeyStore = tempDir.toString() + File.pathSeparator + "keystore.jks";
         km = new KeyManagement(
-            pathToKeyStore,
-            alias,
-            keyStorePassphrase,
-            keyPairPassphrase,
+            new MemoryCertificateStorage(),
             dn,
+            shipId,
             days
         );
     }
@@ -58,6 +61,32 @@ public class KeyManagementTest {
     @AfterEach
     public void tearDown() {
         KeyManagement.clearTrustedSkis();
+    }
+
+    @Test
+    public void test_file_keystore() throws CertificateStoreException, CertificateEncodingException {
+        CertificateStorage storage = this.createKeyStoreCertificateStorage();
+        KeyManagement km = new KeyManagement(storage, dn, shipId, days);
+
+        byte[] encodedPrivateKey = km.getCert().privateKey.getEncoded();
+        byte[] encodedX509Cert = km.getCert().certificate.getEncoded();
+
+        CertificateStorage storage2 = this.createKeyStoreCertificateStorage();
+        var storedCertificate = storage2.readCertificate();
+
+        assertThat(storedCertificate.isPresent(), is(true));
+        assertThat(storedCertificate.get().certificate.getEncoded(), is(encodedX509Cert));
+        assertThat(storedCertificate.get().privateKey.getEncoded(), is(encodedPrivateKey));
+    }
+
+    private CertificateStorage createKeyStoreCertificateStorage() {
+        String pathToKeyStore = tempDir.toString() + File.separator + "keystore.jks";
+        return new KeyStoreCertificateStorage(
+                pathToKeyStore,
+                keystoreAlias,
+                keystorePassphrase,
+                keystoreKeyPassphrase
+        );
     }
 
     @Test


### PR DESCRIPTION
This pull requests moves the logic behind loading and storing the private certificate into a seperate class.
This allows users to implement custom stores.